### PR TITLE
Update hooks for P5R 1.0.4

### DIFF
--- a/P5R.CostumeFramework/Hooks/OutfitDescriptionHook.cs
+++ b/P5R.CostumeFramework/Hooks/OutfitDescriptionHook.cs
@@ -46,7 +46,7 @@ internal unsafe class OutfitDescriptionHook : IGameHook
 
     public void Initialize(IStartupScanner scanner, IReloadedHooks hooks)
     {
-        scanner.Scan("Load Game BMD Hook", "E8 ?? ?? ?? ?? 4C 8B 35 ?? ?? ?? ?? 48 63 CF", result =>
+        scanner.Scan("Load Game BMD Hook", "E8 ?? ?? ?? ?? 4C 8B 3D ?? ?? ?? ?? 8B C8", result =>
         {
             var patch = new string[]
             {

--- a/P5R.CostumeFramework/Hooks/VirtualOutfitsHook.cs
+++ b/P5R.CostumeFramework/Hooks/VirtualOutfitsHook.cs
@@ -12,48 +12,54 @@ internal unsafe class VirtualOutfitsHook
     private readonly nint virtualOutfitsPtr;
 
     private IAsmHook? nextSectionHook;
-    private readonly nint nextSectionPtr;
+    private readonly nint normalSectionSize;
 
     public VirtualOutfitsHook(IStartupScanner scanner, IReloadedHooks hooks)
     {
         this.virtualOutfitsPtr = Marshal.AllocHGlobal(sizeof(VirtualOutfitsSection));
         Marshal.StructureToPtr(new VirtualOutfitsSection(), virtualOutfitsPtr, false);
-        this.nextSectionPtr = Marshal.AllocHGlobal(sizeof(nint));
-
+        this.normalSectionSize = Marshal.AllocHGlobal(sizeof(nint));
+        
         scanner.Scan(
             "Use Virtual Outfit Section",
-            "8B 45 ?? 48 83 C3 04 0F C8 48 63 C8 89 45 ?? E8 ?? ?? ?? ?? 4C 63 45 ?? 48 8B D3 49 8B C8 48 89 05 ?? ?? ?? ?? 48 C1 E9 05",
+            "E8 ?? ?? ?? ?? 4C 63 45 ?? 48 8B D3 49 8B C8 48 89 05 ?? ?? ?? ?? 48 C1 E9 05",
             result =>
             {
-                var patch = new string[]
+                var sectionSizePatch = new string[]
                 {
                     "use64",
-
-                    // Calculate and save pointer to next item section.
-                    "xor rax, rax",
-                    "mov eax, [rdi]",
-                    "bswap eax",
-                    "lea rdi, [rdi + rax + 16]",        // Assumes outfit section always has 12 bytes of padding.
-                                                        // which *should* be true, even if a mod adds new entries.
-                    $"mov rax, {this.nextSectionPtr}",
-                    "mov [rax], rdi",
-
-                    // Set pointer to virtual outfit data.
-                    $"mov rdi, {virtualOutfitsPtr}"
+        
+                    // Save normal section size
+                    "push rdi",
+                    $"lea rdi, [qword {this.normalSectionSize}]",
+                    "mov [rdi], eax",
+                    "pop rdi",
+        
+                    // Get modded section size and make it use that
+                    $"lea rax, [qword {virtualOutfitsPtr}]",
+                    "mov ecx, [qword rax]",
+                    "bswap ecx",
+                    "mov [rbp + 0x10], ecx",
                 };
-
-                this.virtualOutfitsHook = hooks.CreateAsmHook(patch, result, AsmHookBehaviour.ExecuteFirst).Activate();
-
+        
+                this.virtualOutfitsHook = hooks.CreateAsmHook(sectionSizePatch, result, AsmHookBehaviour.ExecuteFirst).Activate();
+        
                 // Fix pointer so it points to the next section
                 // in the original item TBL.
-                var nextSectionAddress = result + 0x82;
+                var nextSectionAddress = result + 0x24;
                 var nextSectionPatch = new string[]
                 {
                     "use64",
-                    $"mov rdi, {this.nextSectionPtr}",
-                    "mov rdi, [rdi]",
-                };
 
+                    // Set pointer to virtual outfits section
+                    $"lea rdx, [qword {virtualOutfitsPtr} + 4]",
+
+                    // Set section length back to what it normally would be (used after this to determine next section location)
+                    $"lea rax, [qword {this.normalSectionSize}]",
+                    "mov eax, [rax]",
+                    "mov [rbp + 0x10], eax",
+                };
+        
                 this.nextSectionHook = hooks.CreateAsmHook(nextSectionPatch, nextSectionAddress, AsmHookBehaviour.ExecuteFirst).Activate();
             });
     }


### PR DESCRIPTION
This updates the hooks to work with P5R version 1.0.4. It's essentially a continuation of #1 from DC, fixing the remaining stuff.

Note that with these changes the mod no longer will work with older versions of the game. Not sure how you want to deal with that, probably link to an older version people can use somewhere.